### PR TITLE
Add BOS fit equation to documentation

### DIFF
--- a/lcoe_calculator_documentation.html
+++ b/lcoe_calculator_documentation.html
@@ -86,7 +86,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         <dd class='col-sm-9'>The component of balance of system cost that scales with the physical size of the system. This includes racking, wiring, and installation labor, for example.</dd>
       </dl>
       <p>*The BOS cost presets are most accurate for module sizes around 1.65 m<sup>2</sup> for residential systems, and 2 m<sup>2</sup> for utility and commercial systems. Results will be less accurate for modules that are significantly larger or smaller.</p>
-      <p>This calculator relies on BOS costs provided by the NREL system benchmark cost model, since a bottom-up system cost model is highly complex compared to the function of this calculator. The BOS cost data is reported as a function of module efficiency and is fit using the following equation: $$c_\text{system} = \frac{c_\text{area}}{\eta1,000\frac{W}{m^2}} + c_\text{power}$$ where \(c_\text{system}\) and \(c_\text{power}\) are in units of $/W, and \(c_\text{area}\) is in units of $/m<sup>2</sup>.</p>
+      <p>This calculator relies on BOS costs provided by the NREL system benchmark cost model, since a bottom-up system cost model is highly complex compared to the function of this calculator. The BOS cost data is reported as a function of module efficiency and is fit using the following equation: $$c_\text{system} = \frac{c_\text{area}}{\eta \times 1000\frac{W}{m^2}} + c_\text{power}$$ where \(\eta\) is the module efficiency, \(c_\text{system}\) and \(c_\text{power}\) are in units of $/W, and \(c_\text{area}\) is in units of $/m<sup>2</sup>.</p>
       <h4>Performance</h4>
       <dl class='row'>
         <dt class='col-sm-3'>Efficiency</dt>

--- a/lcoe_calculator_documentation.html
+++ b/lcoe_calculator_documentation.html
@@ -86,7 +86,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         <dd class='col-sm-9'>The component of balance of system cost that scales with the physical size of the system. This includes racking, wiring, and installation labor, for example.</dd>
       </dl>
       <p>*The BOS cost presets are most accurate for module sizes around 1.65 m<sup>2</sup> for residential systems, and 2 m<sup>2</sup> for utility and commercial systems. Results will be less accurate for modules that are significantly larger or smaller.</p>
-      <p>This calculator relies on BOS costs provided by the NREL system benchmark cost model, since a bottom-up system cost model is highly complex compared to the function of this calculator. The BOS cost data is reported as a function of module efficiency and is fit using the following equation: $$c_\text{system} [\frac{\$}{W}] = \frac{c_\text{area}}{\eta*1000[\frac{W}{m^2}]} + c_\text{power}[\frac{\$}{W}]$$</p>
+      <p>This calculator relies on BOS costs provided by the NREL system benchmark cost model, since a bottom-up system cost model is highly complex compared to the function of this calculator. The BOS cost data is reported as a function of module efficiency and is fit using the following equation: $$c_\text{system} = \frac{c_\text{area}}{\eta1,000\frac{W}{m^2}} + c_\text{power}$$ where \(c_\text{system}\) and \(c_\text{power}\) are in units of $/W, and \(c_\text{area}\) is in units of $/m<sup>2</sup>.</p>
       <h4>Performance</h4>
       <dl class='row'>
         <dt class='col-sm-3'>Efficiency</dt>

--- a/lcoe_calculator_documentation.html
+++ b/lcoe_calculator_documentation.html
@@ -86,7 +86,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         <dd class='col-sm-9'>The component of balance of system cost that scales with the physical size of the system. This includes racking, wiring, and installation labor, for example.</dd>
       </dl>
       <p>*The BOS cost presets are most accurate for module sizes around 1.65 m<sup>2</sup> for residential systems, and 2 m<sup>2</sup> for utility and commercial systems. Results will be less accurate for modules that are significantly larger or smaller.</p>
-      <p>This calculator relies on BOS costs provided by the NREL system benchmark cost model, since a bottom-up system cost model is highly complex compared to the function of this calculator. The BOS cost data is reported as a function of module efficiency and is fit using the following equation: $$c_\text{system} [\frac{\$}{W}] = \frac{c_\text{area}}{\eta*1000[\frac{W}{m^2}]} + c_\text{power}[\frac{\$}{W}]</p>
+      <p>This calculator relies on BOS costs provided by the NREL system benchmark cost model, since a bottom-up system cost model is highly complex compared to the function of this calculator. The BOS cost data is reported as a function of module efficiency and is fit using the following equation: $$c_\text{system} [\frac{\$}{W}] = \frac{c_\text{area}}{\eta*1000[\frac{W}{m^2}]} + c_\text{power}[\frac{\$}{W}]$$</p>
       <h4>Performance</h4>
       <dl class='row'>
         <dt class='col-sm-3'>Efficiency</dt>

--- a/lcoe_calculator_documentation.html
+++ b/lcoe_calculator_documentation.html
@@ -86,6 +86,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         <dd class='col-sm-9'>The component of balance of system cost that scales with the physical size of the system. This includes racking, wiring, and installation labor, for example.</dd>
       </dl>
       <p>*The BOS cost presets are most accurate for module sizes around 1.65 m<sup>2</sup> for residential systems, and 2 m<sup>2</sup> for utility and commercial systems. Results will be less accurate for modules that are significantly larger or smaller.</p>
+      <p>This calculator relies on BOS costs provided by the NREL system benchmark cost model, since a bottom-up system cost model is highly complex compared to the function of this calculator. The BOS cost data is reported as a function of module efficiency and is fit using the following equation: $$c_\text{system} [\frac{\$}{W}] = \frac{c_\text{area}}{\eta*1000[\frac{W}{m^2}]} + c_\text{power}[\frac{\$}{W}]</p>
       <h4>Performance</h4>
       <dl class='row'>
         <dt class='col-sm-3'>Efficiency</dt>

--- a/lcoe_calculator_documentation.html
+++ b/lcoe_calculator_documentation.html
@@ -66,7 +66,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
       <h2>Input parameters</h2>
       <p>These inputs apply separately to the <strong>baseline</strong> and <strong>proposed</strong> technologies.</p>
       <h4>Cost</h4>
-      <p>Module price is calculated by summing the component costs and adding a 15% margin representing the module manufacturer's profit. For more details on balance of system cost calculations, consult the <a href="https://github.com/NREL/PVLCOE/">repository documentation</a>.</p>
+      <p>Module price is calculated by summing the component costs and adding a 15% margin representing the module manufacturer's profit.</p>
       <dl class='row'>
         <dt class='col-sm-3'>Front layer cost</dt>
         <dd class='col-sm-9'>Cost of the glass on the front surface of the module.</dd>


### PR DESCRIPTION
- [ ] Change log is updated
- [ ] Citation is up to date as follows:  
    For PRs to `main`, update the citation with the anticipated
    version number:  

    > Author names, “NREL Comparative PV LCOE Calculator.”  
    >Version X.Y.Z, https://pvlcoe.nrel.gov

    For all other PRs, the citation should read:

    > Author names, “NREL Comparative PV LCOE Calculator.”  
    > Unreleased version (latest release available at https://pvlcoe.nrel.gov )  
    >     
    > _Note: We recommend including the URL for specific commit if citing results from an unreleased version._
