### PR TITLE
fix case in BOS cost tree file name

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+	<meta http-equiv="refresh" content="0; lcoe_calculator.html" />
+</head>
+</html>

--- a/lcoe_calculator.html
+++ b/lcoe_calculator.html
@@ -670,7 +670,7 @@
     <script src='js/bootstrap.min.js'></script>
     <script src='js/nouislider.js'></script>
     <script src='js/PresetTree.js'></script>
-    <script src='js/BosCostTree.js'></script>
+    <script src='js/BOSCostTree.js'></script>
     <script src='js/lcoe_calculator.js'></script>
   </body>
 </html>

--- a/lcoe_calculator.html
+++ b/lcoe_calculator.html
@@ -660,7 +660,7 @@
       </p>
       <div class='card'>
         <div class='card-body'>
-          <p class='card-text'>SJ Andrews, B Smith, MG Deceglie, KA Horowitz, and TJ Silverman. “NREL Comparative PV LCOE Calculator.” Version 2.0.0, August 2021</p>
+          <p class='card-text'>SJ Andrews, B Smith, MG Deceglie, KA Horowitz, and TJ Silverman. “NREL Comparative PV LCOE Calculator.” Version 2.0.1, August 2021</p>
           <p class='card-text'>Note: We recommend including the <a href="https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls#commit-shas" target="_blank">URL for a specific commit</a> if citing results from an unreleased version.</p>
         </div>
       </div>


### PR DESCRIPTION
~- [ ] Change log is updated~ typo fix doesn't need a change log entry
- [x] Citation is up to date as follows:  
    For PRs to `main`, update the citation with the anticipated
    version number:  

    > Author names, “NREL Comparative PV LCOE Calculator.”  
    >Version X.Y.Z, https://pvlcoe.nrel.gov

    For all other PRs, the citation should read:

    > Author names, “NREL Comparative PV LCOE Calculator.”  
    > Unreleased version (latest release available at https://pvlcoe.nrel.gov )  
    >     
    > _Note: We recommend including the URL for specific commit if citing results from an unreleased version._
